### PR TITLE
calculate weights for particles

### DIFF
--- a/robot_localizer/launch/test_bagfile.launch
+++ b/robot_localizer/launch/test_bagfile.launch
@@ -8,7 +8,7 @@
   <arg name="use_gpu_laser" default="true"/>
 
   <node name="map_server" pkg="map_server" type="map_server" args="$(find robot_localizer)/maps/$(arg map_name).yaml"/>
-  <node name="bag_player" pkg="rosbag" type="play" args="$(find robot_localizer)/bags/$(arg map_name).bag --clock --pause" output="screen"/>
+  <node name="bag_player" pkg="rosbag" type="play" args="$(find robot_localizer)/bags/$(arg map_name).bag --clock --start=20" output="screen"/>
 
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find robot_localizer)/rviz/pf.rviz"/>
 

--- a/robot_localizer/rviz/pf.rviz
+++ b/robot_localizer/rviz/pf.rviz
@@ -6,7 +6,7 @@ Panels:
       Expanded:
         - /Global Options1
         - /Status1
-        - /LaserScan1
+        - /Pose1
       Splitter Ratio: 0.5
     Tree Height: 405
   - Class: rviz/Selection
@@ -69,7 +69,7 @@ Visualization Manager:
       Axes Radius: 0.009999999776482582
       Class: rviz/PoseArray
       Color: 255; 25; 0
-      Enabled: true
+      Enabled: false
       Head Length: 0.07000000029802322
       Head Radius: 0.029999999329447746
       Name: PoseArray
@@ -79,7 +79,7 @@ Visualization Manager:
       Shape: Arrow (Flat)
       Topic: /particlecloud
       Unreliable: false
-      Value: true
+      Value: false
     - Alpha: 1
       Autocompute Intensity Bounds: true
       Autocompute Value Bounds:
@@ -92,7 +92,7 @@ Visualization Manager:
       Color: 255; 255; 255
       Color Transformer: Intensity
       Decay Time: 0
-      Enabled: true
+      Enabled: false
       Invert Rainbow: false
       Max Color: 255; 255; 255
       Max Intensity: 10
@@ -109,7 +109,7 @@ Visualization Manager:
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true
-      Value: true
+      Value: false
     - Alpha: 1
       Class: rviz/RobotModel
       Collision Enabled: false
@@ -185,7 +185,7 @@ Visualization Manager:
       Axes Length: 1
       Axes Radius: 0.10000000149011612
       Class: rviz/Pose
-      Color: 255; 25; 0
+      Color: 0; 255; 0
       Enabled: true
       Head Length: 0.30000001192092896
       Head Radius: 0.10000000149011612
@@ -202,15 +202,23 @@ Visualization Manager:
       Marker Topic: /hypotheses
       Name: MarkerArray
       Namespaces:
-        {}
+        hypotheses_visualization: true
       Queue Size: 100
       Value: true
     - Class: rviz/MarkerArray
-      Enabled: true
+      Enabled: false
       Marker Topic: /projected_lidar_visualization
       Name: MarkerArray
       Namespaces:
         {}
+      Queue Size: 100
+      Value: false
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /lidar_visualization
+      Name: MarkerArray
+      Namespaces:
+        lidar_visualization: true
       Queue Size: 100
       Value: true
   Enabled: true
@@ -241,7 +249,7 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/Orbit
-      Distance: 11.637584686279297
+      Distance: 11.369386672973633
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
@@ -249,17 +257,17 @@ Visualization Manager:
         Value: false
       Field of View: 0.7853981852531433
       Focal Point:
-        X: 0.5743227601051331
-        Y: -1.0982974767684937
-        Z: 0.36095988750457764
+        X: 0.26538679003715515
+        Y: 0.1948295682668686
+        Z: 0.35770148038864136
       Focal Shape Fixed Size: true
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 1.5397963523864746
+      Pitch: 1.5697963237762451
       Target Frame: <Fixed Frame>
-      Yaw: 0.14039674401283264
+      Yaw: 0.025397203862667084
     Saved: ~
 Window Geometry:
   Displays:
@@ -277,5 +285,5 @@ Window Geometry:
   Views:
     collapsed: false
   Width: 1294
-  X: 72
+  X: 440
   Y: 27

--- a/robot_localizer/scripts/crop_bag.py
+++ b/robot_localizer/scripts/crop_bag.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+""" This is the code for cropping out the first 20 seconds of the ac109_1 rosbag """
+# This was ultimiately not a necessary tool, but could be useful for examples later on
+import rosbag
+
+cutoff_time = int(20.0e9) # 18 seconds
+
+with rosbag.Bag('../bags/ac109_1.bag', 'w') as outbag:
+    first_message = True
+    for topic, msg, t in rosbag.Bag('../bags/ac109_1_original.bag').read_messages():
+
+        # Just get the start time if this is the first message
+        if first_message:
+            start_time = t.to_nsec() # nanoseconds, one billionth of a second
+            first_message = False
+
+        # Only record a message if it happened after the specified interval
+        # help(t)
+        elif t.to_nsec() - start_time > cutoff_time:
+            outbag.write(topic, msg, t)


### PR DESCRIPTION
This PR adds in the weight calculations for particles, and various quality of life improvements through modifications to `roslaunch` and `rviz`.

#### Calculate Particle Weights
This all happens in the `update_particles_with_laser` method. The process works as follows:
1. Filter out invalid points from the lidar scan
2. Transform polar lidar points to cartesian coordinates
3. Build and publish an array of lidar cartesian points for visualization
4. For each particle:
    1. Transform lidar points so that they're relative to the map, and being projected from the particle.
    2. Get the distance to the closest obstacle for every point in the scan.
    3. Sum all of the distances together.
    4. Calculate the weight as 1/sum-of-distances
5. Normalize the weights for all the particles
6. Build and publish an array of projected lidar points from the first particle in `self.particle_cloud`

#### Rviz Changes
On startup from `roslaunch robot_localizer test_bagfile.launch map_name:=ac109_1`, you now see:
- The absolute position of the robot as a big _green_ arrow
- All of the particles as small, 3D arrows. The greener the arrow, the higher the probability that the robot is there.
- A lidar scan that refreshes only when the weights are updated. The points are visualized as red cubes.
- The RobotModel, unchanged.

#### Roslaunch Change
When you run `roslaunch robot_localizer test_bagfile.launch map_name:=ac109_1`, the bag file now starts playing from the 20 second mark. This makes it so that you don't have to wait 20 seconds before the robot starts moving and particle filter starts updating. Though realistically, it seems like it still takes my Olin laptop about 10 seconds to start updating particle weights even with this change.